### PR TITLE
fix: クエリ結果0件の場合に空の配列が返る不具合を修正

### DIFF
--- a/class/DB_Connector_main.php
+++ b/class/DB_Connector_main.php
@@ -87,8 +87,12 @@ class DB_Connector_main extends DB_Connector {
             $stmt->execute();
             $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-            
-            return $results; //格納されていなければ false を返す
+            // クエリ結果が0件で空の配列が返ってきた場合はfalseを返す
+            if(count($results) == 0) {
+                return false;
+            } else {
+                return $results;
+            }
         } else {
             return self::$connect_error;
         }
@@ -113,8 +117,12 @@ class DB_Connector_main extends DB_Connector {
             $stmt->execute();
             $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-            
-            return $results; //格納されていなければ false を返す
+            // クエリ結果が0件で空の配列が返ってきた場合はfalseを返す
+            if(count($results) == 0) {
+                return false;
+            } else {
+                return $results;
+            }
         } else {
             return self::$connect_error;
         }
@@ -271,7 +279,12 @@ class DB_Connector_main extends DB_Connector {
             $stmt->execute();
             $results = $stmt->fetchAll(PDO::FETCH_COLUMN|PDO::FETCH_GROUP);
 
-            return $results;
+            // クエリ結果が0件で空の配列が返ってきた場合はfalseを返す
+            if(count($results) == 0) {
+                return false;
+            } else {
+                return $results;
+            }
 
         } else {
             // 接続失敗時はstringでエラーメッセージを返す
@@ -335,7 +348,13 @@ class DB_Connector_main extends DB_Connector {
         // var_dump($stmt);
         $stmt->execute();
         $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
-        return $results;
+        
+        // クエリ結果が0件で空の配列が返ってきた場合はfalseを返す
+        if(count($results) == 0) {
+            return false;
+        } else {
+            return $results;
+        }
     }
 
     // あるグループの月別、週別の、特定カテゴリにおけるレコードを取り出すメソッド * 直接呼び出さない
@@ -356,7 +375,13 @@ class DB_Connector_main extends DB_Connector {
         // var_dump($stmt);
         $stmt->execute();
         $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
-        return $results;
+        
+        // クエリ結果が0件で空の配列が返ってきた場合はfalseを返す
+        if(count($results) == 0) {
+            return false;
+        } else {
+            return $results;
+        }
     }
 
     // 月別か週別か期間を選ぶ * 直接呼び出さない


### PR DESCRIPTION
fetchAllは検索結果が0件の場合、空の配列を返す仕様だったため、
これを含む一部メソッドからfalseが返ってこないという不具合の修正を行いました。

(fetchは検索結果が0件の場合、falseを返す仕様なのでそのままにしています)