### PR TITLE
Fix:エラー画面header修正

### DIFF
--- a/view/error.php
+++ b/view/error.php
@@ -12,7 +12,11 @@
 
 <body>
 	<!-- ヘッダー -->
-	<?php include __DIR__ . "/_header.php" ?>
+	<?php if (isset($_SESSION['id'])): ?>
+		<?php include __DIR__ . "/_header.php" ?>
+	<?php else: ?>
+		<?php include __DIR__ . "/_beforeHeader.php" ?>
+	<?php endif; ?>
 	
 	<div class="container">
 		<div class="mt-4"></div>


### PR DESCRIPTION
ログイン前にエラー画面にリダイレクトするとヘッダーの画像が表示されないため、ログイン後に保存される`$_SESSION['id']`がなければログイン前のヘッダーを表示するように変更しました。