### PR TITLE
Add:エラー処理

### DIFF
--- a/class/Config.php
+++ b/class/Config.php
@@ -58,4 +58,29 @@ class Config {
                 break;
         }
     }
+
+    // Internet Exploerでアクセスした場合エラーページへ
+    public static function is_ie()
+    {
+        // ユーザーエージェントを取得
+        $browser = $_SERVER['HTTP_USER_AGENT'];
+        if (strstr($browser, 'Trident') || strstr($browser, 'MSIE')) {
+            header('Location: http://'.$_SERVER['HTTP_HOST'].dirname($_SERVER['SCRIPT_NAME']).'/ieError.php');
+            exit();
+        }
+        return false;
+    }
+
+    // Internet Exploer以外でieErrorページを開かない処理
+    public static function not_ie()
+    {
+        // ユーザーエージェントを取得
+        $browser = $_SERVER['HTTP_USER_AGENT'];
+        if (strstr($browser, 'Trident') || strstr($browser, 'MSIE')) {
+            return true;
+        } else {
+            header('Location: http://'.$_SERVER['HTTP_HOST'].dirname($_SERVER['SCRIPT_NAME']).'/login.php');
+            exit();
+        }
+    }
 } 

--- a/stylesheet/css/ie.css
+++ b/stylesheet/css/ie.css
@@ -1,0 +1,23 @@
+#header-bar {
+    position:fixed;
+    top:0px;
+    left:0px;
+    height:240px;
+    width:100%;
+    z-index:9999;
+    overflow:hidden;
+    background: rgba(153, 153, 153, 0.85);
+}
+
+#header-inner{
+    width: 1080px;
+    display:block;
+    margin:0px auto;
+    text-align: left;
+    font-size: 18px;
+    font-weight: 400;
+    height:200px;
+    margin-top: 30px;
+    color: #fff;
+    z-index:9999;
+}

--- a/userController.php
+++ b/userController.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/class/AutoLoader.php';
 $loader = AutoLoader::registerDirectory(__DIR__);
 $loader = AutoLoader::register();
+Config::is_ie();
 session_start();
 UserLogin::notLogin();
 

--- a/view/ieError.php
+++ b/view/ieError.php
@@ -1,0 +1,32 @@
+<?php
+require_once __DIR__.'/../class/Config.php';
+Config::not_ie()
+?>
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../stylesheet/css/ie.css">
+    <title>Error</title>
+</head>
+<body>
+    <div id="header-bar">
+        <div id="header-inner">このブラウザでは動作保証対象外となります。 
+            <br>引き続きWEBサイトを閲覧する場合は、サポートされているブラウザに切り替えてください。 
+            <br>2021年以降、Windows10で閲覧・動作推奨するブラウザは下記になります。
+            <br>
+            <br>
+            <span clas="edde" style="background: White;padding: 5px 15px;">
+            <a href ="https://www.microsoft.com/ja-jp/edge" style="text-decoration: underline; color:#999;">Microsoft Edge</a>
+            </span>
+            <span clas="chrome" style="background: White;padding: 5px 15px;">
+            <a href="https://www.google.com/chrome/" style="text-decoration: underline; color:#999;">Google Chrome</a>
+            </span>
+            <br>
+            <br>ダウンロードとインストール方法などにつきましては、ブラウザ提供元へお問い合せください。
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Internet Exploerでアクセスした場合に`view/ieError.php`ページを表示。

`class/Config.php`のis_ie()メソッドでブラウザの判定をしており、Userコントローラーで呼び出しています。

Internet Exploer以外のブラウザで直接`view/ieError.php`ページにアクセスした場合`class/Config.php`のnot_ie()メソッドでログインページにリダイレクトします。
